### PR TITLE
Deploy web tunnel script

### DIFF
--- a/.env.backup
+++ b/.env.backup
@@ -1,0 +1,24 @@
+# Since .env is gitignored, you can use .env.example to build a new `.env` file when you clone the repo.
+# Keep this file up-to-date when you add new variables to \`.env\`.
+
+# This file will be committed to version control, so make sure not to have any secrets in it.
+# If you are cloning this repo, create a copy of this file named `.env` and populate it with your secrets.
+
+# The database URL is used to connect to your Supabase database.
+POSTGRES_URL="postgres://postgres.[USERNAME]:[PASSWORD]@aws-0-eu-central-1.pooler.supabase.com:6543/postgres?workaround=supabase-pooler.vercel"
+
+# You can generate the secret via 'openssl rand -base64 32' on Unix
+# @see https://www.better-auth.com/docs/installation
+AUTH_SECRET='supersecret'
+
+# Preconfigured Discord OAuth provider, works out-of-the-box
+# @see https://www.better-auth.com/docs/authentication/discord
+AUTH_DISCORD_ID=''
+AUTH_DISCORD_SECRET=''
+
+# Tunnel Configuration (Optional)
+# Set this to use a custom subdomain for local development tunnels
+# This will be used for Discord OAuth callbacks and other tunnel URLs
+# Example: TUNNEL_SUBDOMAIN="my-app-oauth-dev"
+# Results in: https://my-app-oauth-dev.loca.lt
+TUNNEL_SUBDOMAIN=""

--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,4 @@ AUTH_DISCORD_SECRET=''
 # This will be used for Discord OAuth callbacks and other tunnel URLs
 # Example: TUNNEL_SUBDOMAIN="my-app-oauth-dev"
 # Results in: https://my-app-oauth-dev.loca.lt
-TUNNEL_SUBDOMAIN="myapp-dev"
+TUNNEL_SUBDOMAIN="myapp-dev"TUNNEL_SUBDOMAIN="myapp-dev"

--- a/.env.example
+++ b/.env.example
@@ -21,4 +21,4 @@ AUTH_DISCORD_SECRET=''
 # This will be used for Discord OAuth callbacks and other tunnel URLs
 # Example: TUNNEL_SUBDOMAIN="my-app-oauth-dev"
 # Results in: https://my-app-oauth-dev.loca.lt
-TUNNEL_SUBDOMAIN=""
+TUNNEL_SUBDOMAIN="myapp-dev"

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -164,7 +164,7 @@ install_env_file() {
     # Function to get variable value from .env file
     get_env_var_value() {
         local var_name="$1"
-        grep "^${var_name}=" .env | cut -d'=' -f2- | sed 's/^["'\'']//;s/["'\'']$//'
+        grep "^${var_name}=" .env | cut -d'=' -f2- | sed 's/^["'\'']*//;s/["'\'']*$//'
     }
 
     # Function to get variable value from .env.example file
@@ -247,7 +247,7 @@ get_env_value() {
     # Function to get variable value from .env file
     get_env_var_value() {
         local var_name="$1"
-        grep "^${var_name}=" .env 2>/dev/null | cut -d'=' -f2- | sed 's/^["'\'']//;s/["'\'']$//'
+        grep "^${var_name}=" .env 2>/dev/null | cut -d'=' -f2- | sed 's/^["'\'']*//;s/["'\'']*$//'
     }
 
     # Function to get variable value from .env.example file

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -182,7 +182,7 @@ install_env_file() {
     # Function to get variable value from shell environment
     get_shell_var_value() {
         local var_name="$1"
-        eval "echo \$${var_name}"
+        printf '%s' "${!var_name}"
     }
 
     # Get all variables from .env.example
@@ -259,7 +259,7 @@ get_env_value() {
     # Function to get variable value from shell environment
     get_shell_var_value() {
         local var_name="$1"
-        eval "echo \$${var_name}"
+        printf '%s' "${!var_name}"
     }
     
     # Get values from all sources

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -148,6 +148,8 @@ install_env_file() {
     if [ ! -f ".env" ]; then
         log_info "Creating .env file from .env.example..."
         cp .env.example .env
+        # Ensure proper line endings
+        dos2unix .env 2>/dev/null || true
     fi
 
     # Function to extract variable names from .env.example (excluding comments and empty lines)

--- a/web_output.log
+++ b/web_output.log
@@ -6,10 +6,13 @@
 > @acme/nextjs@0.1.0 with-env /workspace/apps/nextjs
 > dotenv -e ../../.env -- next dev --turbopack
 
- ⚠ Port 3000 is in use, using available port 3005 instead.
    ▲ Next.js 15.3.3 (Turbopack)
-   - Local:        http://localhost:3005
-   - Network:      http://172.30.0.2:3005
+   - Local:        http://localhost:3000
+   - Network:      http://172.30.0.2:3000
 
  ✓ Starting...
- ✓ Ready in 927ms
+ ✓ Ready in 973ms
+ ○ Compiling / ...
+ ✓ Compiled / in 4.9s
+[TRPC] post.all took 892ms to execute
+ GET / 200 in 6169ms

--- a/web_output.log
+++ b/web_output.log
@@ -12,4 +12,4 @@
    - Network:      http://172.30.0.2:3002
 
  ✓ Starting...
- ✓ Ready in 988ms
+ ✓ Ready in 984ms

--- a/web_output.log
+++ b/web_output.log
@@ -24,3 +24,5 @@
  GET / 200 in 888ms
 [TRPC] post.all took 541ms to execute
  GET / 200 in 590ms
+[TRPC] post.all took 936ms to execute
+ GET / 200 in 987ms

--- a/web_output.log
+++ b/web_output.log
@@ -11,18 +11,16 @@
    - Network:      http://172.30.0.2:3000
 
  ✓ Starting...
- ✓ Ready in 995ms
+ ✓ Ready in 1012ms
  ○ Compiling / ...
- ✓ Compiled / in 4.5s
-[TRPC] post.all took 841ms to execute
- GET / 200 in 4677ms
-[TRPC] post.all took 1057ms to execute
- GET / 200 in 5974ms
-[TRPC] post.all took 504ms to execute
- GET / 200 in 556ms
-[TRPC] post.all took 250ms to execute
- GET / 200 in 298ms
-[TRPC] post.all took 512ms to execute
- GET / 200 in 565ms
-[TRPC] post.all took 1016ms to execute
- GET / 200 in 1078ms
+ ✓ Compiled / in 4.9s
+[TRPC] post.all took 958ms to execute
+ GET / 200 in 6357ms
+[TRPC] post.all took 1076ms to execute
+ GET / 200 in 5162ms
+[TRPC] post.all took 388ms to execute
+ GET / 200 in 434ms
+[TRPC] post.all took 827ms to execute
+ GET / 200 in 888ms
+[TRPC] post.all took 541ms to execute
+ GET / 200 in 590ms

--- a/web_output.log
+++ b/web_output.log
@@ -12,4 +12,4 @@
    - Network:      http://172.30.0.2:3002
 
  ✓ Starting...
- ✓ Ready in 993ms
+ ✓ Ready in 988ms

--- a/web_output.log
+++ b/web_output.log
@@ -11,10 +11,16 @@
    - Network:      http://172.30.0.2:3000
 
  ✓ Starting...
- ✓ Ready in 961ms
+ ✓ Ready in 1030ms
  ○ Compiling / ...
- ✓ Compiled / in 5.3s
-[TRPC] post.all took 1177ms to execute
- GET / 200 in 7019ms
-[TRPC] post.all took 532ms to execute
- GET / 200 in 585ms
+ ✓ Compiled / in 5s
+[TRPC] post.all took 935ms to execute
+ GET / 200 in 6319ms
+[TRPC] post.all took 1136ms to execute
+ GET / 200 in 2316ms
+[TRPC] post.all took 463ms to execute
+ GET / 200 in 524ms
+[TRPC] post.all took 395ms to execute
+ GET / 200 in 448ms
+[TRPC] post.all took 286ms to execute
+ GET / 200 in 341ms

--- a/web_output.log
+++ b/web_output.log
@@ -34,3 +34,5 @@ Read more: https://nextjs.org/docs/app/api-reference/config/next-config-js/allow
  ✓ Compiled /api/auth/[...all] in 1478ms
 [2m2025-08-12T02:16:06.667Z[0m [31mERROR[0m [1m[Better Auth]:[0m State not found undefined
  GET /api/auth/callback/discord?code=Z8BEMSYrQZ4WbmuA6yy7G7L68qfmq3 302 in 2247ms
+[TRPC] post.all took 905ms to execute
+ GET / 200 in 1038ms

--- a/web_output.log
+++ b/web_output.log
@@ -11,18 +11,16 @@
    - Network:      http://172.30.0.2:3000
 
  ✓ Starting...
- ✓ Ready in 1030ms
+ ✓ Ready in 995ms
  ○ Compiling / ...
- ✓ Compiled / in 5s
-[TRPC] post.all took 935ms to execute
- GET / 200 in 6319ms
-[TRPC] post.all took 1136ms to execute
- GET / 200 in 2316ms
-[TRPC] post.all took 463ms to execute
- GET / 200 in 524ms
-[TRPC] post.all took 395ms to execute
- GET / 200 in 448ms
-[TRPC] post.all took 286ms to execute
- GET / 200 in 341ms
-[TRPC] post.all took 1029ms to execute
- GET / 200 in 1093ms
+ ✓ Compiled / in 4.5s
+[TRPC] post.all took 841ms to execute
+ GET / 200 in 4677ms
+[TRPC] post.all took 1057ms to execute
+ GET / 200 in 5974ms
+[TRPC] post.all took 504ms to execute
+ GET / 200 in 556ms
+[TRPC] post.all took 250ms to execute
+ GET / 200 in 298ms
+[TRPC] post.all took 512ms to execute
+ GET / 200 in 565ms

--- a/web_output.log
+++ b/web_output.log
@@ -20,3 +20,17 @@
  GET / 200 in 2258ms
 [TRPC] post.all took 247ms to execute
  GET / 200 in 294ms
+[TRPC] post.all took 750ms to execute
+ GET / 200 in 814ms
+ ⚠ Cross origin request detected from gopher-assuring-seriously.ngrok-free.app to /_next/* resource. In a future major version of Next.js, you will need to explicitly configure "allowedDevOrigins" in next.config to allow this.
+Read more: https://nextjs.org/docs/app/api-reference/config/next-config-js/allowedDevOrigins
+ POST / 303 in 123ms
+[TRPC] post.all took 1055ms to execute
+ GET / 200 in 1113ms
+[TRPC] post.all took 505ms to execute
+ GET / 200 in 547ms
+ POST / 303 in 97ms
+ ○ Compiling /api/auth/[...all] ...
+ ✓ Compiled /api/auth/[...all] in 1478ms
+[2m2025-08-12T02:16:06.667Z[0m [31mERROR[0m [1m[Better Auth]:[0m State not found undefined
+ GET /api/auth/callback/discord?code=Z8BEMSYrQZ4WbmuA6yy7G7L68qfmq3 302 in 2247ms

--- a/web_output.log
+++ b/web_output.log
@@ -24,3 +24,5 @@
  GET / 200 in 298ms
 [TRPC] post.all took 512ms to execute
  GET / 200 in 565ms
+[TRPC] post.all took 1016ms to execute
+ GET / 200 in 1078ms

--- a/web_output.log
+++ b/web_output.log
@@ -6,10 +6,10 @@
 > @acme/nextjs@0.1.0 with-env /workspace/apps/nextjs
 > dotenv -e ../../.env -- next dev --turbopack
 
- ⚠ Port 3000 is in use, using available port 3002 instead.
+ ⚠ Port 3000 is in use, using available port 3005 instead.
    ▲ Next.js 15.3.3 (Turbopack)
-   - Local:        http://localhost:3002
-   - Network:      http://172.30.0.2:3002
+   - Local:        http://localhost:3005
+   - Network:      http://172.30.0.2:3005
 
  ✓ Starting...
- ✓ Ready in 984ms
+ ✓ Ready in 927ms

--- a/web_output.log
+++ b/web_output.log
@@ -24,3 +24,5 @@
  GET / 200 in 448ms
 [TRPC] post.all took 286ms to execute
  GET / 200 in 341ms
+[TRPC] post.all took 1029ms to execute
+ GET / 200 in 1093ms

--- a/web_output.log
+++ b/web_output.log
@@ -11,18 +11,12 @@
    - Network:      http://172.30.0.2:3000
 
  ✓ Starting...
- ✓ Ready in 1012ms
+ ✓ Ready in 967ms
  ○ Compiling / ...
- ✓ Compiled / in 4.9s
-[TRPC] post.all took 958ms to execute
- GET / 200 in 6357ms
-[TRPC] post.all took 1076ms to execute
- GET / 200 in 5162ms
-[TRPC] post.all took 388ms to execute
- GET / 200 in 434ms
-[TRPC] post.all took 827ms to execute
- GET / 200 in 888ms
-[TRPC] post.all took 541ms to execute
- GET / 200 in 590ms
-[TRPC] post.all took 936ms to execute
- GET / 200 in 987ms
+ ✓ Compiled / in 4.4s
+[TRPC] post.all took 986ms to execute
+[TRPC] post.all took 1014ms to execute
+ GET / 200 in 5846ms
+ GET / 200 in 2258ms
+[TRPC] post.all took 247ms to execute
+ GET / 200 in 294ms

--- a/web_output.log
+++ b/web_output.log
@@ -11,8 +11,10 @@
    - Network:      http://172.30.0.2:3000
 
  ✓ Starting...
- ✓ Ready in 973ms
+ ✓ Ready in 961ms
  ○ Compiling / ...
- ✓ Compiled / in 4.9s
-[TRPC] post.all took 892ms to execute
- GET / 200 in 6169ms
+ ✓ Compiled / in 5.3s
+[TRPC] post.all took 1177ms to execute
+ GET / 200 in 7019ms
+[TRPC] post.all took 532ms to execute
+ GET / 200 in 585ms

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,0 @@
-your url is: https://orange-bat-54.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,1 @@
-your url is: https://hungry-firefox-81.loca.lt
+your url is: https://silly-frog-20.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,1 @@
-your url is: https://cold-frog-15.loca.lt
+your url is: https://orange-bat-54.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,1 @@
-your url is: https://afraid-catfish-70.loca.lt
+your url is: https://cold-frog-15.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,1 @@
-your url is: https://perfect-skunk-85.loca.lt
+your url is: https://hungry-firefox-81.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,0 @@
-your url is: https://silly-frog-20.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,1 @@
-your url is: https://weak-snake-50.loca.lt
+your url is: https://perfect-skunk-85.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,0 +1,1 @@
+your url is: https://weak-snake-50.loca.lt

--- a/web_tunnel_output.log
+++ b/web_tunnel_output.log
@@ -1,1 +1,1 @@
-your url is: https://tender-eel-19.loca.lt
+your url is: https://afraid-catfish-70.loca.lt


### PR DESCRIPTION
Fix deploy script and `.env.example` to correctly configure web tunnel subdomain.

The `deploy.sh` script was incorrectly parsing and writing environment variables, especially `TUNNEL_SUBDOMAIN`, due to issues with `eval` and handling of quotes/line endings. This led to the tunnel URL being malformed. The fix involves safer variable parsing and ensuring correct `.env` file generation.

---
<a href="https://cursor.com/background-agent?bcId=bc-7f0a5840-6736-423b-8ba5-92683602d666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7f0a5840-6736-423b-8ba5-92683602d666">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

